### PR TITLE
+check for already registred user for /api/auth/register

### DIFF
--- a/controllers/users.go
+++ b/controllers/users.go
@@ -75,15 +75,6 @@ func (t *UsersController) SignUpUser(ctx *gin.Context) {
 		return
 	}
 
-	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
-	if err == nil {
-		ctx.JSON(http.StatusConflict, gin.H{
-			"status": "failed",
-			"data":   "User with such email already registred.",
-		})
-		return
-	}
-
 	user, err := t.userService.SignUpUser(ctx, inputModel)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{

--- a/controllers/users.go
+++ b/controllers/users.go
@@ -75,6 +75,15 @@ func (t *UsersController) SignUpUser(ctx *gin.Context) {
 		return
 	}
 
+	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
+	if err == nil {
+		ctx.JSON(http.StatusConflict, gin.H{
+			"status": "failed",
+			"data":   "User with such email already registred.",
+		})
+		return
+	}
+
 	user, err := t.userService.SignUpUser(ctx, inputModel)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{

--- a/services/users.go
+++ b/services/users.go
@@ -42,6 +42,12 @@ func (t *ServiceUsers) LoginUser(ctx *gin.Context, inputModel models.InLogin) (s
 
 func (t *ServiceUsers) SignUpUser(ctx *gin.Context, inputModel queries.User) (queries.User, error) {
 
+	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
+	if err == nil {
+		err = fmt.Errorf("User with such email already registred.")
+		return queries.User{}, err
+	}
+
 	hashedPassword := HashPassword(inputModel.Password)
 
 	args := &queries.CreateUserParams{

--- a/services/users.go
+++ b/services/users.go
@@ -43,13 +43,13 @@ func (t *ServiceUsers) LoginUser(ctx *gin.Context, inputModel models.InLogin) (s
 
 func (t *ServiceUsers) SignUpUser(ctx *gin.Context, inputModel queries.User) (queries.User, error) {
 
-	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
+	registred, err := t.db.GetUserByEmail(ctx, inputModel.Email)
 
 	if (err != nil) && (err != sql.ErrNoRows) {
 		err = fmt.Errorf("DB search error.")
 		return queries.User{}, err
 	}
-	if err == nil {
+	if registred.Email == inputModel.Email {
 		err = fmt.Errorf("User with such email already registred.")
 		return queries.User{}, err
 	}

--- a/services/users.go
+++ b/services/users.go
@@ -1,11 +1,13 @@
 package services
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/cr1m3s/tch_backend/models"
 	"github.com/cr1m3s/tch_backend/queries"
+	db "github.com/cr1m3s/tch_backend/queries"
 	"github.com/gin-gonic/gin"
 )
 
@@ -42,8 +44,8 @@ func (t *ServiceUsers) LoginUser(ctx *gin.Context, inputModel models.InLogin) (s
 
 func (t *ServiceUsers) SignUpUser(ctx *gin.Context, inputModel queries.User) (queries.User, error) {
 
-	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
-	if err == nil {
+	registred, err := t.db.GetUserByEmail(ctx, inputModel.Email)
+	if (registred != db.User{}) && (err != sql.ErrNoRows) {
 		err = fmt.Errorf("User with such email already registred.")
 		return queries.User{}, err
 	}

--- a/services/users.go
+++ b/services/users.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cr1m3s/tch_backend/models"
 	"github.com/cr1m3s/tch_backend/queries"
-	db "github.com/cr1m3s/tch_backend/queries"
 	"github.com/gin-gonic/gin"
 )
 
@@ -44,8 +43,13 @@ func (t *ServiceUsers) LoginUser(ctx *gin.Context, inputModel models.InLogin) (s
 
 func (t *ServiceUsers) SignUpUser(ctx *gin.Context, inputModel queries.User) (queries.User, error) {
 
-	registred, err := t.db.GetUserByEmail(ctx, inputModel.Email)
-	if (registred != db.User{}) && (err != sql.ErrNoRows) {
+	_, err := t.db.GetUserByEmail(ctx, inputModel.Email)
+
+	if (err != nil) && (err != sql.ErrNoRows) {
+		err = fmt.Errorf("DB search error.")
+		return queries.User{}, err
+	}
+	if err == nil {
 		err = fmt.Errorf("User with such email already registred.")
 		return queries.User{}, err
 	}


### PR DESCRIPTION
Returns 409  when using email of already registred user for POST /api/ath/register.